### PR TITLE
Update docker-img-usage.sh

### DIFF
--- a/docker-img-usage.sh
+++ b/docker-img-usage.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 docker_find_files () {
   #echo -e "\e[96m  Largest Files (+200M)\e[0m"
-  docker_find_files_results=$(docker exec $1 sh -c '/usr/bin/find / -xdev $2 -path ./proc -prune -o -path ./sys -prune -o -type f -size +200000k -exec du -Shx {} + | sort -rh | head | sed "s/^/    /"')
+  docker_find_files_results=$(docker exec $1 sh -c '/usr/bin/find / -xdev $2 -path ./proc -prune -o -path ./sys -prune -o -type f -size +200000k -exec du -shx {} + | sort -r | head | sed "s/^/    /"')
 }
 
 docker_find_directories () {
   #echo -e "\e[96m  Largest Directories (+200M)\e[0m"
-  docker_find_directories_results=$(docker exec $1 sh -c 'du -hxa --threshold=200M / $2 | sort -rh | head | sed "s/^/    /"')
+  docker_find_directories_results=$(docker exec $1 sh -c 'du -hxa / $2 | sort -r | head | sed "s/^/    /"')
 }
 
 docker_find_subdirectories () {
   #echo -e "\e[96m  Largest Directories (+200M) (excluding subdirectories)\e[0m"
-  docker_find_subdirectories_results=$(docker exec $1 sh -c 'du -Shx --threshold=200M / $2 | sort -rh | head | sed "s/^/    /"')
+  docker_find_subdirectories_results=$(docker exec $1 sh -c 'du -shx / $2 | sort -r | head | sed "s/^/    /"')
 }
 
 docker_get_mounts () {
@@ -30,21 +30,21 @@ docker_set_exclude_dir () {
 
 results () {
   if [[ ! -z $docker_find_files_results || ! -z $docker_find_directories_results || ! -z $docker_find_subdirectories_results ]]; then
-    echo -e "\e[32;4m$1\e[0m"
+    echo -e "\e[$1\e]"
   fi 
   
   if [[ ! -z $docker_find_files_results ]]; then
-    echo -e "\e[96m  Largest Files (+200M)\e[0m"
+    echo -e "\e[Largest Files \e]"
 	echo $docker_find_files_results
   fi 
 
   if [[ ! -z $docker_find_directories_results ]]; then
-    echo -e "\e[96m  Largest Directories (+200M)\e[0m"
+    echo -e "\e[Largest Directories \e]"
 	echo $docker_find_directories_results
   fi 
 
   if [[ ! -z $docker_find_subdirectories_results ]]; then
-    echo -e "\e[96m  Largest Directories (+200M) (excluding subdirectories)\e[0m"
+    echo -e "\e[Largest Directories (excluding subdirectories)\e]"
 	echo $docker_find_subdirectories_results
   fi
 


### PR DESCRIPTION
fixed unrecognized option errors and removed the 200M threshold since the output is short as well as cleaned up the output labels, removing the "96m/" in the results which didn't refer to anything (that I understand at least)